### PR TITLE
Update main property to ng-tasty-tpls.js

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -5,7 +5,7 @@
   "authors": [
     { "name" : "Leonardo Zizzamia", "homepage" : "https://twitter.com/Zizzamia" }
   ],
-  "main": "./ng-tasty.js",
+  "main": "./ng-tasty-tpls.js",
   "dependencies": {
     "angular": "^1.3.0"
   }


### PR DESCRIPTION
Right now the **main** property is pointing to **ng-tasty**

```
{
  "name": "ng-tasty",
  "version": "0.5.0",
  "homepage": "https://github.com/Zizzamia/ng-tasty",
  "authors": [
    { "name" : "Leonardo Zizzamia", "homepage" : "https://twitter.com/Zizzamia" }
  ],
  "main": "./ng-tasty.js", // should be ng-tasty-tpls.js
  "dependencies": {
    "angular": "^1.3.0"
  }
}
```

I'm using wiredep to inject bower dependencies in my html and got this error:

https://docs.angularjs.org/error/$injector/nomod?p0=ngTasty.tpls.table.head

If I change the value of the main property to **ng-tasty-tpls.js** it works well.
